### PR TITLE
Capture full update differences and metadata

### DIFF
--- a/src/differ.py
+++ b/src/differ.py
@@ -18,16 +18,20 @@ import os
 import json
 import base64
 import asyncio
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from pyrogram import Client
 from pyrogram.errors import InternalServerError, Unauthorized
 
+from pyrogram.raw import types
 from pyrogram.raw.functions.updates.get_difference import GetDifference
 from pyrogram.raw.types.updates.difference import Difference
 from pyrogram.raw.types.updates.difference_slice import DifferenceSlice
 from pyrogram.raw.types.updates.difference_empty import DifferenceEmpty
 from pyrogram.raw.types.updates.difference_too_long import DifferenceTooLong
+from pyrogram.raw.functions.users import GetUsers
+from pyrogram.raw.functions.channels import GetChannels
+from pyrogram.raw.functions.messages import GetChats
 
 # --- App credentials (yours) ---
 APP_ID = 28221462
@@ -43,51 +47,62 @@ def _ensure_dirs() -> None:
     os.makedirs(OUT_DIR, exist_ok=True)
 
 
-def _to_jsonable(obj: Any) -> Any:
-    """
-    Best-effort conversion of Pyrogram raw TLObjects (and nested structures)
-    into JSON-serializable data. Bytes are base64-encoded. Adds '__type__'
-    to preserve the original class name for objects.
-    """
-    from datetime import datetime
-    from enum import Enum
-
+def _serialize(obj: Any) -> Any:
+    """Recursively convert TL objects into JSON-friendly dicts."""
     if obj is None or isinstance(obj, (str, int, float, bool)):
         return obj
 
     if isinstance(obj, bytes):
-        return {"__bytes__": base64.b64encode(obj).decode("ascii")}
+        return {"_": "bytes", "data": base64.b64encode(obj).decode("ascii")}
 
-    if isinstance(obj, (list, tuple, set)):
-        return [_to_jsonable(x) for x in obj]
+    if isinstance(obj, list):
+        return [_serialize(x) for x in obj]
 
     if isinstance(obj, dict):
-        return {str(k): _to_jsonable(v) for k, v in obj.items()}
+        return {str(k): _serialize(v) for k, v in obj.items()}
 
-    if isinstance(obj, datetime):
-        return obj.isoformat()
+    if isinstance(obj, types.TLObject):
+        data = {"_": f"types.{obj.__class__.__name__}"}
+        for k, v in obj.__dict__.items():
+            if k.startswith("_"):
+                continue
+            data[k] = _serialize(v)
+        return data
 
-    if isinstance(obj, Enum):
-        return obj.name
-
-    # Try a dict-like view of custom objects (e.g., TLObjects)
-    # Keep only public attributes, annotate with type
+    # Fallback: represent other objects as dict
     if hasattr(obj, "__dict__"):
-        d = {k: v for k, v in obj.__dict__.items() if not k.startswith("_")}
-        d["__type__"] = obj.__class__.__name__
-        return _to_jsonable(d)
+        data = {"_": obj.__class__.__name__}
+        for k, v in obj.__dict__.items():
+            if k.startswith("_"):
+                continue
+            data[k] = _serialize(v)
+        return data
 
-    # Fallback: string representation
     return repr(obj)
 
 
-async def _collect_diffs(token: str) -> Tuple[int, List[Any]]:
-    """
-    Connect with a bot token, page through GetDifference, and collect
-    all new_messages across slices.
-    Returns (uid, messages_list).
-    """
-    # Use the numeric bot ID as the session name to avoid collisions
+def _deserialize(data: Any) -> Any:
+    """Reconstruct TL objects from data produced by ``_serialize``."""
+    if isinstance(data, list):
+        return [_deserialize(x) for x in data]
+
+    if isinstance(data, dict):
+        t = data.get("_")
+        if t == "bytes":
+            return base64.b64decode(data["data"])
+        if t and t.startswith("types."):
+            cls_name = t.split(".", 1)[1]
+            cls = getattr(types, cls_name)
+            kwargs = {k: _deserialize(v) for k, v in data.items() if k != "_"}
+            return cls(**kwargs)
+        return {k: _deserialize(v) for k, v in data.items() if k != "_"}
+
+    return data
+
+
+async def _collect_diffs(token: str) -> Tuple[int, Dict[str, Any]]:
+    """Fetch full update difference and related objects."""
+
     session_name = str(token).split(":")[0]
 
     async with Client(
@@ -102,81 +117,122 @@ async def _collect_diffs(token: str) -> Tuple[int, List[Any]]:
         me = await client.get_me()
         uid = me.id
 
-        req = GetDifference(pts=1, date=1, qts=0)
-        collected: List[Any] = []
+        req = GetDifference(pts=0, date=0, qts=0)
+        diff_data: Dict[str, Any] = {
+            "new_messages": [],
+            "new_encrypted_messages": [],
+            "other_updates": [],
+            "chats": [],
+            "users": [],
+            "state": None,
+        }
 
         while True:
             try:
                 diff = await client.invoke(req)
-                print(diff)
-                print(type(diff))
-                print("--------------")
             except InternalServerError:
-                # Transient server hiccup; just retry current req
                 continue
             except Unauthorized:
-                # Token revoked or invalid; return nothing for this uid
-                return uid, []
+                return uid, diff_data
 
             if isinstance(diff, DifferenceSlice):
-                # Accumulate messages
-                if diff.new_messages:
-                    collected.extend(diff.new_messages)
+                diff_data["new_messages"].extend(diff.new_messages or [])
+                diff_data["new_encrypted_messages"].extend(diff.new_encrypted_messages or [])
+                diff_data["other_updates"].extend(diff.other_updates or [])
+                diff_data["chats"].extend(diff.chats or [])
+                diff_data["users"].extend(diff.users or [])
 
-                # Advance state
                 st = diff.intermediate_state
                 req.pts = st.pts
                 req.qts = st.qts
                 req.date = st.date
 
             elif isinstance(diff, Difference):
-                if diff.new_messages:
-                    collected.extend(diff.new_messages)
+                diff_data["new_messages"].extend(diff.new_messages or [])
+                diff_data["new_encrypted_messages"].extend(diff.new_encrypted_messages or [])
+                diff_data["other_updates"].extend(diff.other_updates or [])
+                diff_data["chats"].extend(diff.chats or [])
+                diff_data["users"].extend(diff.users or [])
+                diff_data["state"] = diff.state
                 break
 
             elif isinstance(diff, DifferenceTooLong):
-                # Server tells us to jump to a newer pts
                 req.pts = diff.pts
 
             elif isinstance(diff, DifferenceEmpty):
-                # Nothing more to do
+                diff_data["state"] = diff.state
                 break
 
-        return uid, collected
+        # Filter messages: exclude outgoing simple messages
+        filtered: List[types.TLObject] = []
+        for m in diff_data["new_messages"]:
+            if isinstance(m, types.MessageService):
+                filtered.append(m)
+            elif isinstance(m, types.Message):
+                if not getattr(m, "out", False):
+                    filtered.append(m)
+            else:
+                filtered.append(m)
+        diff_data["new_messages"] = filtered
+
+        # Fetch full user objects
+        input_users = []
+        for u in diff_data["users"]:
+            if isinstance(u, types.User) and getattr(u, "access_hash", None) is not None:
+                input_users.append(types.InputUser(user_id=u.id, access_hash=u.access_hash))
+        if input_users:
+            users_full = await client.invoke(GetUsers(id=input_users))
+            diff_data["users"] = users_full
+        else:
+            diff_data["users"] = []
+
+        # Fetch full channel objects
+        channel_inputs = []
+        for c in list(diff_data["chats"]):
+            if isinstance(c, types.Channel) and getattr(c, "access_hash", None) is not None:
+                channel_inputs.append(types.InputChannel(channel_id=c.id, access_hash=c.access_hash))
+        channels_full: List[types.TLObject] = []
+        if channel_inputs:
+            res = await client.invoke(GetChannels(id=channel_inputs))
+            channels_full.extend(res.chats)
+
+        # Fetch full basic group chats
+        chat_id_list = [c.id for c in diff_data["chats"] if isinstance(c, types.Chat)]
+        chats_full: List[types.TLObject] = []
+        if chat_id_list:
+            res = await client.invoke(GetChats(id=chat_id_list))
+            chats_full.extend(res.chats)
+
+        diff_data["chats"] = channels_full + chats_full
+
+        return uid, diff_data
 
 
-async def get_updates_async(token: str, save_to_json: bool) -> Optional[List[Any]]:
-    """
-    Async entrypoint. If save_to_json=True, writes to OUT_DIR/<uid>.json and returns None.
-    Otherwise returns a list of raw Pyrogram TLObjects.
-    """
+async def get_updates_async(token: str, save_to_json: bool) -> Optional[Dict[str, Any]]:
+    """Fetch updates and optionally persist them to JSON."""
+
     _ensure_dirs()
 
-    uid, messages = await _collect_diffs(token)
+    uid, data = await _collect_diffs(token)
 
     if save_to_json:
-        # Serialize once at the end to avoid partial/corrupt files
         out_path = os.path.join(OUT_DIR, f"{uid}.json")
         with open(out_path, "w", encoding="utf-8") as f:
-            json.dump(_to_jsonable(messages), f, ensure_ascii=False)
+            json.dump(_serialize(data), f, ensure_ascii=False)
         return None
 
-    # Return the raw Pyrogram objects (variables/objects in memory)
-    return messages
+    return data
 
 
-def get_updates(token: str, save_to_json: bool) -> Optional[List[Any]]:
-    """
-    Sync wrapper. Call this from another script with only (token, bool).
-    If an event loop is already running, import and use `await get_updates_async(...)`.
-    """
+def get_updates(token: str, save_to_json: bool) -> Optional[Dict[str, Any]]:
+    """Synchronous wrapper around ``get_updates_async``."""
+
     try:
         return asyncio.run(get_updates_async(token, save_to_json))
     except RuntimeError as e:
-        # Helpful message if called from within a running loop (e.g., FastAPI, Jupyter)
         if "asyncio.run()" in str(e):
             raise RuntimeError(
-                "An asyncio event loop is already running. "
-                "Use: `await get_updates_async(token, save_to_json)`."
+                "An asyncio event loop is already running. Use: "
+                "`await get_updates_async(token, save_to_json)`."
             ) from e
         raise

--- a/src/loader.py
+++ b/src/loader.py
@@ -1,10 +1,9 @@
 # loader.py
 import os
 import json
-import pyrogram
-from typing import List, Any
+from typing import Any, Dict, List
 
-from .differ import get_updates, get_updates_async, OUT_DIR  # re-use your module
+from .differ import OUT_DIR, get_updates_async, _deserialize
 
 def bot_uid_from_token(token: str) -> str:
     t = token.strip()
@@ -12,34 +11,24 @@ def bot_uid_from_token(token: str) -> str:
         t = t[3:]
     return t.split(":", 1)[0]
 
-async def load_messages(token: str, new=False) -> List[Any]:
-    """
-    Ensures JSON exists for the token (generates via get_updates if missing),
-    loads it, then reconstructs TL objects via your eval(eval(...)) approach.
-    Returns a flat list of TL objects (e.g., pyrogram.raw.types.Message).
-    """
+async def load_difference(token: str, new: bool = False) -> Dict[str, Any]:
+    """Load previously dumped updates for a bot token."""
+
     uid = bot_uid_from_token(token)
     os.makedirs(OUT_DIR, exist_ok=True)
     json_path = os.path.join(OUT_DIR, f"{uid}.json")
 
-    if os.path.isfile(json_path) and not new:
-        with open(json_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    else:
+    if not os.path.isfile(json_path) or new:
         await get_updates_async(token, save_to_json=True)
-        with open(json_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
 
-    messages = []
-    for item in (data or []):
-        try:
-            obj = eval(eval(json.dumps(item, ensure_ascii=False)))
-            if isinstance(obj, list):
-                messages.extend(obj)
-            else:
-                messages.append(obj)
-        except Exception:
-            print("***** Skipping invalid message *****")
-            continue
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
 
-    return messages
+    return _deserialize(data)
+
+
+async def load_messages(token: str, new: bool = False) -> List[Any]:
+    """Convenience wrapper returning only ``new_messages``."""
+
+    diff = await load_difference(token, new)
+    return diff.get("new_messages", [])


### PR DESCRIPTION
## Summary
- Collect full update difference data including messages, users, chats, and state
- Filter out outgoing messages while keeping service messages
- Serialize/deserialize TL objects and provide loader to fetch stored updates

## Testing
- `python -m py_compile src/differ.py src/loader.py src/__main__.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a1536114832993344459ce1cd34e