### PR TITLE
Download full updates and store user and chat info

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,133 +1,27 @@
-# list_users_from_messages.py
+"""Simple command line entry point.
+
+Running ``python -m diffbot`` downloads the latest updates for the token
+stored in the ``TOKEN`` constant below and prints a short summary.  The
+JSON result is saved to ``out/<bot_id>.json``.
+"""
+
+from __future__ import annotations
+
 import asyncio
-from collections import defaultdict
-from typing import Iterable, List
 
-from pyrogram import Client
-from .loader import load_messages
-from .differ import APP_ID, APP_HASH, WORK_DIR  # reuse your constants
+from .loader import load_updates
 
-TOKEN = "7592149177:AAF1kLRe-7w1TKNtoNN9WUpDpITfvc021qU"  # <-- your bot token here
-new = True  # load new messages
+# Replace this with the token of the bot you want to inspect.
+TOKEN = "7592149177:AAF1kLRe-7w1TKNtoNN9WUpDpITfvc021qU"
 
-def chunked(it: Iterable[int], size: int) -> Iterable[List[int]]:
-    it = list(it)
-    for i in range(0, len(it), size):
-        yield it[i:i + size]
 
-def channel_to_chat_id(channel_id: int) -> int:
-    # Telegram supergroup/channel chat_id is -100<channel_id> (concatenation, not multiplication)
-    return int(f"-100{channel_id}")
+async def main() -> None:
+    data = await load_updates(TOKEN, new=True)
+    print(f"Loaded {len(data.get('new_messages', []))} messages")
+    print(f"Loaded {len(data.get('users', []))} users")
+    print(f"Loaded {len(data.get('chats', []))} chats")
 
-def basicgroup_to_chat_id(chat_id: int) -> int:
-    # Basic group chat_id is the negative of its id
-    return -int(chat_id)
-
-async def main():
-    # 1) Load & reconstruct messages
-    msgs = await load_messages(TOKEN, new)
-
-    # 2) Inspect and collect
-    checked_messages = 0
-    user_ids = set()                # incoming users only (m.out == False)
-    channel_ids = set()             # raw channel_id from peer_id
-    chat_ids = set()                # raw chat_id (basic groups)
-    service_action_counts = defaultdict(int)
-    other_types_counts = defaultdict(int)
-
-    for m in msgs:
-        checked_messages += 1
-
-        # Peer classification: users, channels, chats
-        peer = getattr(m, "peer_id", None)
-        if peer is not None:
-            uid = getattr(peer, "user_id", None)
-            if isinstance(uid, int):
-                if not getattr(m, "out", False):
-                    user_ids.add(uid)
-            cid = getattr(peer, "channel_id", None)
-            if isinstance(cid, int):
-                channel_ids.add(cid)
-            gid = getattr(peer, "chat_id", None)
-            if isinstance(gid, int):
-                chat_ids.add(gid)
-
-        # Message kind classification
-        cls = m.__class__.__name__
-        if cls == "MessageService":
-            action = getattr(m, "action", None)
-            action_name = action.__class__.__name__ if action else "UnknownAction"
-            service_action_counts[action_name] += 1
-        elif cls not in ("Message",):
-            # Track other unusual message kinds (MessageEmpty, etc.)
-            other_types_counts[cls] += 1
-
-    # Quick summary
-    print(f"Found {len(user_ids)} unique incoming user IDs.")
-    print(f"Found {len(channel_ids)} unique channels.")
-    print(f"Found {len(chat_ids)} unique basic groups (chats).")
-    total_service = sum(service_action_counts.values())
-    print(f"Found {total_service} service messages.")
-
-    if other_types_counts:
-        print("Other message types:", ", ".join(f"{k}={v}" for k, v in other_types_counts.items()))
-
-    # 3) Fetch and print users, channels, and chats
-    session_name = str(TOKEN).split(":", 1)[0]
-    async with Client(
-        session_name,
-        bot_token=TOKEN,
-        api_id=APP_ID,
-        api_hash=APP_HASH,
-        workdir=WORK_DIR,
-        workers=1,
-        no_updates=True,
-    ) as app:
-        # Users
-        if user_ids:
-            print("\n== Incoming users ==")
-            for batch in chunked(sorted(user_ids), 100):
-                users = await app.get_users(batch)
-                if not isinstance(users, list):
-                    users = [users]
-                for u in users:
-                    full_name = " ".join(filter(None, [u.first_name, u.last_name])) or "(no name)"
-                    username = f"@{u.username}" if u.username else "(no username)"
-                    print(f"USER {u.id}: {full_name} {username}")
-
-        # Channels / Supergroups
-        if channel_ids:
-            print("\n== Channels / Supergroups ==")
-            for ch in sorted(channel_ids):
-                chat_id = channel_to_chat_id(ch)
-                try:
-                    c = await app.get_chat(chat_id)
-                    title = getattr(c, "title", None) or getattr(c, "first_name", "") or "(no title)"
-                    username = f"@{c.username}" if getattr(c, "username", None) else "(no username)"
-                    print(f"CHANNEL {c.id}: {title} {username}")
-                except Exception as e:
-                    print(f"CHANNEL -100{ch}: <unavailable> ({type(e).__name__})")
-
-        # Basic groups (legacy chats)
-        if chat_ids:
-            print("\n== Basic groups (chats) ==")
-            for gid in sorted(chat_ids):
-                chat_id = basicgroup_to_chat_id(gid)
-                try:
-                    c = await app.get_chat(chat_id)
-                    title = getattr(c, "title", None) or "(no title)"
-                    username = f"@{c.username}" if getattr(c, "username", None) else "(no username)"
-                    print(f"CHAT {c.id}: {title} {username}")
-                except Exception as e:
-                    print(f"CHAT -{gid}: <unavailable> ({type(e).__name__})")
-
-    # 4) End-of-run stats
-    if service_action_counts:
-        print("\n== Service messages by action ==")
-        for name, count in sorted(service_action_counts.items()):
-            print(f"{name}: {count}")
-
-    print(f"\nTotal messages checked: {checked_messages}")
 
 if __name__ == "__main__":
     asyncio.run(main())
+

--- a/src/differ.py
+++ b/src/differ.py
@@ -1,94 +1,110 @@
-# differ.py
-# -----------------------------------------------------------
-# Single-call API:
-#   get_updates(token: str, save_to_json: bool) -> Optional[list]
-#
-# If save_to_json=True:
-#   - writes JSON to out/<uid>.json
-#   - returns None
-#
-# If save_to_json=False:
-#   - returns a list of Pyrogram TL objects (raw messages)
-#   - does not write any files
-#
-# Requires: pyrogram
-# -----------------------------------------------------------
+"""Download full update information from Telegram bots.
 
-import os
-import json
-import base64
+This module connects to Telegram using Pyrogram's raw ``GetDifference``
+method and stores everything returned by the server: messages, service
+messages, chats, users and the final update state.  In contrast to the
+previous revision which only saved ``new_messages`` and attempted to
+serialise TL objects using ``eval`` tricks, this version produces a
+plain JSON file that mirrors the structure shown in Telegram's MTProto
+documentation.
+
+Only incoming regular messages are saved – outgoing messages of type
+``Message`` are discarded.  Service messages (``MessageService``) are
+always preserved even if they were sent by the bot itself.
+
+Example
+-------
+
+>>> from diffbot.differ import get_updates
+>>> get_updates("123456:ABCDEF", save_to_json=True)
+
+This will create ``out/<bot_id>.json`` containing a structure similar to
+``updates.Difference``.
+"""
+
+from __future__ import annotations
+
 import asyncio
-from typing import Any, List, Optional, Tuple
+import base64
+import json
+import os
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from pyrogram import Client
 from pyrogram.errors import InternalServerError, Unauthorized
-
 from pyrogram.raw.functions.updates.get_difference import GetDifference
+from pyrogram.raw.types import Message, MessageService
 from pyrogram.raw.types.updates.difference import Difference
-from pyrogram.raw.types.updates.difference_slice import DifferenceSlice
 from pyrogram.raw.types.updates.difference_empty import DifferenceEmpty
+from pyrogram.raw.types.updates.difference_slice import DifferenceSlice
 from pyrogram.raw.types.updates.difference_too_long import DifferenceTooLong
 
-# --- App credentials (yours) ---
+# ---------------------------------------------------------------------------
+# Credentials and paths
+
 APP_ID = 28221462
 APP_HASH = "929b210afa6e5226caeb5ec9a80f64a9"
 
-# --- Local paths ---
 OUT_DIR = "out"
 WORK_DIR = "sessions"
 
 
 def _ensure_dirs() -> None:
-    os.makedirs(WORK_DIR, exist_ok=True)
     os.makedirs(OUT_DIR, exist_ok=True)
+    os.makedirs(WORK_DIR, exist_ok=True)
 
 
-def _to_jsonable(obj: Any) -> Any:
-    """
-    Best-effort conversion of Pyrogram raw TLObjects (and nested structures)
-    into JSON-serializable data. Bytes are base64-encoded. Adds '__type__'
-    to preserve the original class name for objects.
-    """
-    from datetime import datetime
-    from enum import Enum
+# ---------------------------------------------------------------------------
+# Helpers
+
+def _tl_to_dict(obj: Any) -> Any:
+    """Convert Pyrogram TLObjects into plain Python dictionaries."""
 
     if obj is None or isinstance(obj, (str, int, float, bool)):
         return obj
 
     if isinstance(obj, bytes):
-        return {"__bytes__": base64.b64encode(obj).decode("ascii")}
+        return base64.b64encode(obj).decode("ascii")
 
-    if isinstance(obj, (list, tuple, set)):
-        return [_to_jsonable(x) for x in obj]
-
-    if isinstance(obj, dict):
-        return {str(k): _to_jsonable(v) for k, v in obj.items()}
-
-    if isinstance(obj, datetime):
-        return obj.isoformat()
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return [_tl_to_dict(x) for x in obj]
 
     if isinstance(obj, Enum):
         return obj.name
 
-    # Try a dict-like view of custom objects (e.g., TLObjects)
-    # Keep only public attributes, annotate with type
     if hasattr(obj, "__dict__"):
-        d = {k: v for k, v in obj.__dict__.items() if not k.startswith("_")}
-        d["__type__"] = obj.__class__.__name__
-        return _to_jsonable(d)
+        data: Dict[str, Any] = {"_": f"types.{obj.__class__.__name__}"}
+        for k, v in obj.__dict__.items():
+            if k.startswith("_"):
+                continue
+            data[k] = _tl_to_dict(v)
+        return data
 
-    # Fallback: string representation
     return repr(obj)
 
 
-async def _collect_diffs(token: str) -> Tuple[int, List[Any]]:
-    """
-    Connect with a bot token, page through GetDifference, and collect
-    all new_messages across slices.
-    Returns (uid, messages_list).
-    """
-    # Use the numeric bot ID as the session name to avoid collisions
-    session_name = str(token).split(":")[0]
+def _chunked(it: Iterable[int], size: int) -> Iterable[List[int]]:
+    seq = list(it)
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+def _channel_to_chat_id(channel_id: int) -> int:
+    return int(f"-100{channel_id}")
+
+
+def _basicgroup_to_chat_id(chat_id: int) -> int:
+    return -int(chat_id)
+
+
+# ---------------------------------------------------------------------------
+# Core difference collection
+
+async def _collect_difference(token: str) -> Tuple[int, Dict[str, Any]]:
+    """Collect the full ``updates.Difference`` for the given bot token."""
+
+    session_name = str(token).split(":", 1)[0]
 
     async with Client(
         session_name,
@@ -98,85 +114,167 @@ async def _collect_diffs(token: str) -> Tuple[int, List[Any]]:
         workdir=WORK_DIR,
         workers=1,
         no_updates=True,
-    ) as client:
-        me = await client.get_me()
+    ) as app:
+        me = await app.get_me()
         uid = me.id
 
-        req = GetDifference(pts=1, date=1, qts=0)
-        collected: List[Any] = []
+        # Aggregated containers
+        messages: List[Any] = []
+        other_updates: List[Any] = []
+        chats: List[Any] = []
+        users: List[Any] = []
+        new_encrypted: List[Any] = []
+        state: Any = None
+
+        req = GetDifference(pts=0, date=0, qts=0)
 
         while True:
             try:
-                diff = await client.invoke(req)
-                print(diff)
-                print(type(diff))
-                print("--------------")
+                diff = await app.invoke(req)
             except InternalServerError:
-                # Transient server hiccup; just retry current req
                 continue
             except Unauthorized:
-                # Token revoked or invalid; return nothing for this uid
-                return uid, []
+                return uid, {}
 
             if isinstance(diff, DifferenceSlice):
-                # Accumulate messages
-                if diff.new_messages:
-                    collected.extend(diff.new_messages)
-
-                # Advance state
+                messages.extend(diff.new_messages or [])
+                other_updates.extend(diff.other_updates or [])
+                chats.extend(diff.chats or [])
+                users.extend(diff.users or [])
+                new_encrypted.extend(diff.new_encrypted_messages or [])
                 st = diff.intermediate_state
                 req.pts = st.pts
                 req.qts = st.qts
                 req.date = st.date
+                continue
 
-            elif isinstance(diff, Difference):
-                if diff.new_messages:
-                    collected.extend(diff.new_messages)
-                break
-
-            elif isinstance(diff, DifferenceTooLong):
-                # Server tells us to jump to a newer pts
+            if isinstance(diff, DifferenceTooLong):
                 req.pts = diff.pts
+                continue
 
-            elif isinstance(diff, DifferenceEmpty):
-                # Nothing more to do
+            if isinstance(diff, DifferenceEmpty):
+                state = diff.state
                 break
 
-        return uid, collected
+            if isinstance(diff, Difference):
+                messages.extend(diff.new_messages or [])
+                other_updates.extend(diff.other_updates or [])
+                chats.extend(diff.chats or [])
+                users.extend(diff.users or [])
+                new_encrypted.extend(diff.new_encrypted_messages or [])
+                state = diff.state
+                break
+
+        # ------------------------------------------------------------------
+        # Filter and gather identifiers for full info
+        filtered_messages: List[Any] = []
+        user_ids: set[int] = set()
+        channel_ids: set[int] = set()
+        chat_ids: set[int] = set()
+
+        for m in messages:
+            if isinstance(m, Message) and getattr(m, "out", False):
+                # Skip outgoing regular messages
+                continue
+
+            filtered_messages.append(m)
+            peer = getattr(m, "peer_id", None)
+            if peer is not None:
+                uid = getattr(peer, "user_id", None)
+                if isinstance(uid, int):
+                    user_ids.add(uid)
+                cid = getattr(peer, "channel_id", None)
+                if isinstance(cid, int):
+                    channel_ids.add(cid)
+                gid = getattr(peer, "chat_id", None)
+                if isinstance(gid, int):
+                    chat_ids.add(gid)
+
+        for u in users:
+            if getattr(u, "id", None) is not None:
+                user_ids.add(u.id)
+
+        for c in chats:
+            name = c.__class__.__name__
+            if name == "Channel":
+                channel_ids.add(c.id)
+            elif name == "Chat":
+                chat_ids.add(c.id)
+
+        # Fetch full user information
+        full_users: List[Any] = []
+        if user_ids:
+            for batch in _chunked(sorted(user_ids), 100):
+                fetched = await app.get_users(batch)
+                if not isinstance(fetched, list):
+                    fetched = [fetched]
+                full_users.extend(fetched)
+
+        # Fetch full chat/channel information
+        full_chats: List[Any] = []
+        for cid in sorted(channel_ids):
+            chat_id = _channel_to_chat_id(cid)
+            try:
+                full_chats.append(await app.get_chat(chat_id))
+            except Exception:
+                continue
+
+        for gid in sorted(chat_ids):
+            chat_id = _basicgroup_to_chat_id(gid)
+            try:
+                full_chats.append(await app.get_chat(chat_id))
+            except Exception:
+                continue
+
+        result = {
+            "_": "types.updates.Difference",
+            "new_messages": [_tl_to_dict(m) for m in filtered_messages],
+            "new_encrypted_messages": [_tl_to_dict(m) for m in new_encrypted],
+            "other_updates": [_tl_to_dict(u) for u in other_updates],
+            "chats": [_tl_to_dict(c) for c in full_chats],
+            "users": [_tl_to_dict(u) for u in full_users],
+            "state": _tl_to_dict(state),
+        }
+
+        return uid, result
 
 
-async def get_updates_async(token: str, save_to_json: bool) -> Optional[List[Any]]:
+# ---------------------------------------------------------------------------
+# Public API
+
+async def get_updates_async(token: str, save_to_json: bool) -> Optional[Dict[str, Any]]:
+    """Fetch updates for ``token``.
+
+    If ``save_to_json`` is ``True`` the result is written to
+    ``out/<uid>.json`` and ``None`` is returned.  Otherwise the parsed
+    dictionary is returned directly.
     """
-    Async entrypoint. If save_to_json=True, writes to OUT_DIR/<uid>.json and returns None.
-    Otherwise returns a list of raw Pyrogram TLObjects.
-    """
+
     _ensure_dirs()
-
-    uid, messages = await _collect_diffs(token)
+    uid, data = await _collect_difference(token)
 
     if save_to_json:
-        # Serialize once at the end to avoid partial/corrupt files
-        out_path = os.path.join(OUT_DIR, f"{uid}.json")
-        with open(out_path, "w", encoding="utf-8") as f:
-            json.dump(_to_jsonable(messages), f, ensure_ascii=False)
+        path = os.path.join(OUT_DIR, f"{uid}.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
         return None
 
-    # Return the raw Pyrogram objects (variables/objects in memory)
-    return messages
+    return data
 
 
-def get_updates(token: str, save_to_json: bool) -> Optional[List[Any]]:
-    """
-    Sync wrapper. Call this from another script with only (token, bool).
-    If an event loop is already running, import and use `await get_updates_async(...)`.
-    """
+def get_updates(token: str, save_to_json: bool) -> Optional[Dict[str, Any]]:
+    """Synchronous wrapper for :func:`get_updates_async`."""
+
     try:
         return asyncio.run(get_updates_async(token, save_to_json))
-    except RuntimeError as e:
-        # Helpful message if called from within a running loop (e.g., FastAPI, Jupyter)
-        if "asyncio.run()" in str(e):
+    except RuntimeError as e:  # pragma: no cover - helper for running loops
+        if "asyncio.run" in str(e):
             raise RuntimeError(
-                "An asyncio event loop is already running. "
-                "Use: `await get_updates_async(token, save_to_json)`."
+                "An asyncio event loop is already running. Use "
+                "`await get_updates_async(token, save_to_json)` instead."
             ) from e
         raise
+
+
+__all__ = ["get_updates", "get_updates_async", "APP_ID", "APP_HASH", "OUT_DIR", "WORK_DIR"]
+

--- a/src/loader.py
+++ b/src/loader.py
@@ -1,45 +1,47 @@
-# loader.py
-import os
-import json
-import pyrogram
-from typing import List, Any
+"""Utility helpers for reading the saved update JSON files."""
 
-from .differ import get_updates, get_updates_async, OUT_DIR  # re-use your module
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any, Dict
+
+from .differ import OUT_DIR, get_updates_async
+
 
 def bot_uid_from_token(token: str) -> str:
+    """Extract the numeric identifier from a bot token."""
+
     t = token.strip()
     if t.startswith("bot"):
         t = t[3:]
     return t.split(":", 1)[0]
 
-async def load_messages(token: str, new=False) -> List[Any]:
+
+async def load_updates(token: str, new: bool = False) -> Dict[str, Any]:
+    """Load the saved difference for ``token``.
+
+    When ``new`` is ``True`` or the file does not yet exist the latest
+    updates are fetched from Telegram first.
     """
-    Ensures JSON exists for the token (generates via get_updates if missing),
-    loads it, then reconstructs TL objects via your eval(eval(...)) approach.
-    Returns a flat list of TL objects (e.g., pyrogram.raw.types.Message).
-    """
+
     uid = bot_uid_from_token(token)
+    path = os.path.join(OUT_DIR, f"{uid}.json")
     os.makedirs(OUT_DIR, exist_ok=True)
-    json_path = os.path.join(OUT_DIR, f"{uid}.json")
 
-    if os.path.isfile(json_path) and not new:
-        with open(json_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    else:
+    if new or not os.path.isfile(path):
         await get_updates_async(token, save_to_json=True)
-        with open(json_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
 
-    messages = []
-    for item in (data or []):
-        try:
-            obj = eval(eval(json.dumps(item, ensure_ascii=False)))
-            if isinstance(obj, list):
-                messages.extend(obj)
-            else:
-                messages.append(obj)
-        except Exception:
-            print("***** Skipping invalid message *****")
-            continue
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
 
-    return messages
+
+def load_updates_sync(token: str, new: bool = False) -> Dict[str, Any]:
+    """Synchronous wrapper around :func:`load_updates`."""
+
+    return asyncio.run(load_updates(token, new=new))
+
+
+__all__ = ["load_updates", "load_updates_sync", "bot_uid_from_token"]
+


### PR DESCRIPTION
## Summary
- Rework MTProto difference downloader to capture messages, users, chats and state
- Provide loader utilities for reading saved difference JSON files
- Add simple CLI entry point for fetching updates and printing a summary

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6897a1536114832993344459ce1cd34e